### PR TITLE
Setup data directory once at startup

### DIFF
--- a/doc2.d
+++ b/doc2.d
@@ -4083,7 +4083,8 @@ void main(string[] args) {
 		// write out the landing page for JS search,
 		// see the comment in the source of that html
 		// for more details
-		writeFile(outputDirectory ~ "search-docs.html", import("search-docs.html"), gzip);
+		auto searchDocsHtml = std.file.readText(findStandardFile("search-docs.html"));
+		writeFile(buildPath(outputDirectory, "search-docs.html"), searchDocsHtml, gzip);
 
 
 		// the search index is a HTML page containing some script

--- a/dub.json
+++ b/dub.json
@@ -5,7 +5,7 @@
 	"homepage": "https://github.com/adamdruppe/adrdox",
 	"license": "BSL-1.0",
 
-	"copyFiles": ["skeleton-default.html", "script.js", "style.css", "search-docs.js", "katex"],
+	"copyFiles": ["skeleton-default.html", "script.js", "style.css", "search-docs.js", "search-docs.html", "katex"],
 	"targetPath": "build",
 	"targetType": "executable",
 	"buildRequirements": ["allowWarnings"],


### PR DESCRIPTION
Closes #37 

* Added `--data-dir` command line option to set data directory
* Added possibility to give data directory using environment variable "ADRDOX_DATA_DIR"
* Added auto detecting data directory using some known paths
* Added "search-docs.html" to standard files instead of import