### PR TITLE
Added CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,101 @@
+name: CI
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+  pull_request:
+jobs:
+  build:
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+        dc:
+          - dmd-latest
+          - ldc-latest
+          - dmd-beta
+          - ldc-beta
+        profile:
+          - debug
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Setup D compiler
+        uses: dlang-community/setup-dlang@v1
+        with:
+          compiler: ${{ matrix.dc }}
+      - name: Checkout source
+        uses: actions/checkout@v2
+      - name: Build binary
+        run: dub build -b ${{ matrix.profile }}
+
+  build-release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs:
+      - build
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - name: linux-i686
+            os: ubuntu-latest
+            arch: x86
+          - name: linux-x86_64
+            os: ubuntu-latest
+            arch: x86_64
+          - name: macos-x86_64
+            os: macos-latest
+            arch: x86_64
+          - name: windows-i686
+            os: windows-latest
+            arch: x86
+          - name: windows-x86_64
+            os: windows-latest
+            arch: x86_64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - if: matrix.name == 'linux-i686'
+        run: |
+          sudo dpkg --add-architecture i386
+          sudo apt-get update
+          sudo apt-get install -y gcc-multilib
+      - name: Setup D compiler
+        uses: dlang-community/setup-dlang@v1
+        with:
+          compiler: ldc-latest
+      - name: Checkout source
+        uses: actions/checkout@v2
+      - name: Build binary release
+        run: dub build -a ${{ matrix.arch }} -b release
+      - name: Create dist
+        uses: papeloto/action-zip@v1
+        with:
+          files: build README.md
+          dest: adrdox_${{ matrix.name }}.zip
+      - name: Upload dist
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: adrdox_${{ matrix.name }}.zip
+
+  publish-release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs:
+      - build-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download dists
+        uses: actions/download-artifact@v2
+        with:
+          name: dist
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          files: '*.zip'
+          #prerelease: true
+          draft: true


### PR DESCRIPTION
Because currently continuous integration is missing I added it using github actions.

I added the following tasks to workflow:
1. `build` which builds executable on different target systems (linux/windows/macos) by different compilers (dmd/ldc, latest/beta)
2. `build-release` which builds binary distributions (when new version issued via tag) for different target systems (linux/windows/macos) and target architectures (i686, x86_64)
3. `publish-release` which publishes created binary distributions using github releases (new draft release will be created)

That CI acts for master branch, for version tags (which looks like v1.2.3) and for pull requests.

The first task runs in any case, the second and third runs only when version tag pushed.