### PR TITLE
Properly fix the 'DSO missing from commandline' problem

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -12,5 +12,6 @@
 
 	"sourcePaths": ["Dscanner/libdparse/src"],
 	"sourceFiles": ["doc2.d", "latex.d", "jstex.d", "cgi.d", "comment.d", "stemmer.d", "dom.d", "archive.d", "jsvar.d", "script.d", "color.d", "Dscanner/src/astprinter.d"],
-	"stringImportPaths": ["."]
+	"stringImportPaths": ["."],
+	"libs": [ "z" ]
 }


### PR DESCRIPTION
There seems to be some indirect reference to libz.so . Latest version of LD rejects indirect references. The proper way is to give all DSOs on the commandline.

So libz was added to the library list.

Needs to be tested on non-Linux platforms! (I do not have Windows anymore)