### PR TITLE
Fix dub build on Windows

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -13,5 +13,5 @@
 	"sourcePaths": ["Dscanner/libdparse/src"],
 	"sourceFiles": ["doc2.d", "latex.d", "jstex.d", "cgi.d", "comment.d", "stemmer.d", "dom.d", "archive.d", "jsvar.d", "script.d", "color.d", "Dscanner/src/astprinter.d"],
 	"stringImportPaths": ["."],
-	"libs": [ "z" ]
+	"libs-posix": [ "z" ]
 }


### PR DESCRIPTION
This resolves the `cannot open file 'z.lib'` link error on Windows.

One could wonder why Posix needs this, but judging by commit 159dab3fa, it does.