### PR TITLE
Support $(U underlined text).

### DIFF
--- a/comment.d
+++ b/comment.d
@@ -1899,6 +1899,7 @@ shared static this() {
 		"TT" : "<tt>$0</tt>",
 		"B" : "<b>$0</b>",
 		"STRIKE" : "<s>$0</s>",
+		"U" : "<u>$0</u>",
 		"P" : "<p>$0</p>",
 		"PRE" : "<pre>$0</pre>",
 		"DL" : "<dl>$0</dl>",


### PR DESCRIPTION
The docs already say it is supported.
https://dpldocs.info/experimental-docs/adrdox.syntax.html#ddoc-macro-to-html-tag-reference