### PR TITLE
Make DMD a variable in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,16 @@
 LIBDPARSE=Dscanner/libdparse/src/dparse/ast.d Dscanner/libdparse/src/dparse/formatter.d Dscanner/libdparse/src/dparse/parser.d Dscanner/libdparse/src/dparse/entities.d  Dscanner/libdparse/src/dparse/lexer.d Dscanner/libdparse/src/std/experimental/lexer.d Dscanner/src/astprinter.d
+DMD?=dmd
 
 all:
-	#dmd diff.d terminal.d $(LIBDPARSE)
-	dmd -debug -m64 doc2.d latex.d jstex.d syntaxhighlighter.d comment.d stemmer.d dom.d script.d jsvar.d color.d archive.d -J. $(LIBDPARSE) -g # -version=std_parser_verbose 
+	#$(DMD) diff.d terminal.d $(LIBDPARSE)
+	$(DMD) -debug -m64 doc2.d latex.d jstex.d syntaxhighlighter.d comment.d stemmer.d dom.d script.d jsvar.d color.d archive.d -J. $(LIBDPARSE) -g # -version=std_parser_verbose 
 	# it may pull in script.d and jsvar.d later fyi
 	#
-	#dmd -of/var/www/dpldocs.info/locate locate.d  dom.d stemmer.d  cgi -J. -version=fastcgi -m64 -debug
+	#$(DMD) -of/var/www/dpldocs.info/locate locate.d  dom.d stemmer.d  cgi -J. -version=fastcgi -m64 -debug
 pq:
-	dmd -m64 doc2.d latex.d jstex.d syntaxhighlighter.d comment.d stemmer.d dom.d script.d jsvar.d color.d archive.d -version=with_postgres database.d postgres.d -L-L/usr/local/pgsql/lib -L-lpq -J. $(LIBDPARSE) -g # -version=std_parser_verbose 
+	$(DMD) -m64 doc2.d latex.d jstex.d syntaxhighlighter.d comment.d stemmer.d dom.d script.d jsvar.d color.d archive.d -version=with_postgres database.d postgres.d -L-L/usr/local/pgsql/lib -L-lpq -J. $(LIBDPARSE) -g # -version=std_parser_verbose 
 locate:
-	dmd -oflocate locate.d  dom.d stemmer.d  cgi -J. -version=scgi -m64 -debug postgres.d archive.d database.d -L-L/usr/local/pgsql/lib -g
+	$(DMD) -oflocate locate.d  dom.d stemmer.d  cgi -J. -version=scgi -m64 -debug postgres.d archive.d database.d -L-L/usr/local/pgsql/lib -g
 
 vps_locate:
 	ldc2i -oflocate_vps -oq -O3 -m64 locate.d  stemmer.d -J. -d-version=scgi -d-version=vps -g -L-L/usr/local/pgsql/lib -L-lpq
@@ -18,4 +19,4 @@ ldc:
 	echo ldc2 -oq -O3 --d-debug -m64 doc2.d latex.d jstex.d syntaxhighlighter.d comment.d archive.d stemmer.d dom.d color.d -J. $(LIBDPARSE) --d-version=with_postgres database.d postgres.d -L-L/usr/local/pgsql/lib -L-lpq -g # -version=std_parser_verbose 
 
 http:
-	dmd -debug -ofserver -version=embedded_httpd -version=with_http_server -m64 doc2.d latex.d archive.d jstex.d cgi.d syntaxhighlighter.d comment.d stemmer.d dom.d script.d jsvar.d color.d -J. $(LIBDPARSE) -g # -version=std_parser_verbose 
+	$(DMD) -debug -ofserver -version=embedded_httpd -version=with_http_server -m64 doc2.d latex.d archive.d jstex.d cgi.d syntaxhighlighter.d comment.d stemmer.d dom.d script.d jsvar.d color.d -J. $(LIBDPARSE) -g # -version=std_parser_verbose 


### PR DESCRIPTION
Make DMD a variable in the Makefile.
Enables users to do things like `$  DMD=ldmd2 make all`.