### PR TITLE
Add missing source file.

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -11,7 +11,7 @@
 	"buildRequirements": ["allowWarnings"],
 
 	"sourcePaths": ["Dscanner/libdparse/src"],
-	"sourceFiles": ["doc2.d", "latex.d", "jstex.d", "cgi.d", "comment.d", "stemmer.d", "dom.d", "archive.d", "jsvar.d", "script.d", "color.d", "Dscanner/src/astprinter.d"],
+	"sourceFiles": ["doc2.d", "latex.d", "jstex.d", "cgi.d", "comment.d", "stemmer.d", "dom.d", "archive.d", "jsvar.d", "script.d", "color.d", "syntaxhighlighter.d", "Dscanner/src/astprinter.d"],
 	"stringImportPaths": ["."],
 	"libs-posix": [ "z" ]
 }


### PR DESCRIPTION
Fixes dub build error "comment.d(5,8): Error: unable to read module `syntaxhighlighter`".